### PR TITLE
feat: construct ethereum light client update headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4456,6 +4456,7 @@ dependencies = [
  "hermes-runtime-components",
  "hermes-test-components",
  "ics008-wasm-client",
+ "protos",
  "serde",
  "unionlabs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ sp1-prover = { version = "3.0.0", default-features = false }
 
 beacon-api = { git = "https://github.com/unionlabs/union", rev = "22495bd" }
 unionlabs = { git = "https://github.com/unionlabs/union", rev = "22495bd" }
+eth-protos = { package = "protos", git = "https://github.com/unionlabs/union", rev = "22495bd" }
 ics008-wasm-client = { git = "https://github.com/unionlabs/union", rev = "22495bd" }
 
 hermes-prover-components = { version = "0.1.0" }

--- a/crates/ethereum-chain-components/Cargo.toml
+++ b/crates/ethereum-chain-components/Cargo.toml
@@ -14,8 +14,9 @@ serde = { workspace = true, features = ["derive"] }
 alloy = { workspace = true, features = ["full"] }
 bincode = { workspace = true }
 beacon-api = { workspace = true }
-unionlabs= { workspace = true }
+unionlabs = { workspace = true }
 ics008-wasm-client = { workspace = true }
+eth-protos = { workspace = true }
 
 cgp = { workspace = true }
 hermes-test-components = { workspace = true }

--- a/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
+++ b/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
@@ -148,6 +148,17 @@ where
             }
         };
 
+        // we can only skip headers within a period. this is similar to validator set change in Tendermint light client.
+        //
+        // examples when the network period is 64:
+        // 1. the trusted height is in [1, 64) and the target height is 217,
+        // we perform updates for 64, 128, 192, 217
+        // where 64, 128 and 192 are the period changes (with next sync committee)
+        // and 217 is the target height (without next sync committee, i.e. current sync committee is trusted)
+        //
+        // 2. if the trusted height is in [64, 128) and the target height is 192,
+        // we perform updates for 128 and 192 (with next sync committee)
+
         let headers = {
             let trust_period = trusted_height.revision_height / spec.period();
             let target_period = target_height.revision_height / spec.period();

--- a/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
+++ b/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
@@ -46,6 +46,7 @@ where
     async fn build_update_client_payload(
         chain: &Chain,
         trusted_height: &Chain::Height,
+        // TODO(rano): maybe this should be called minimum target height
         target_height: &Chain::Height,
         _client_state: Chain::ClientState,
     ) -> Result<EthUpdateClientPayload<Preset>, Chain::Error> {
@@ -53,7 +54,7 @@ where
             return Err("revision number mismatch".to_string());
         }
 
-        // TODO(rano): need to know the finality update at the target height. so, fetching the latest one.
+        // need to know the finality update at the target height. so, fetching the latest one.
         // so, it is possible that the update is in the future of the target height.
 
         let finality_update = chain

--- a/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
+++ b/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
@@ -166,10 +166,13 @@ where
         // 1. the trusted height is in [1, 64) and the target height is 217,
         // we perform updates for 64, 128, 192, 217
         // where 64, 128 and 192 are the period changes (with next sync committee)
-        // and 217 is the target height (without next sync committee, i.e. current sync committee is trusted)
+        // and 217 is the target height (without next sync committee, i.e. current sync committee is trusted).
         //
         // 2. if the trusted height is in [64, 128) and the target height is 192,
-        // we perform updates for 128 and 192 (with next sync committee)
+        // we perform updates for 128 and 192 (with next sync committee).
+        //
+        // 3. if the trusted height i in [64, 128) and the target height is 120,
+        // we perform update only for 120.
 
         let headers = {
             let trust_period = trusted_height.revision_height / spec.period();

--- a/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
+++ b/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
@@ -215,23 +215,21 @@ where
             let mut headers = Vec::with_capacity(n_headers + 1);
 
             for update in light_client_updates {
+                let next_sync_committee = update
+                    .next_sync_committee
+                    .as_ref()
+                    .ok_or_else(|| "missing next sync committee after period change")?
+                    .clone();
+
                 let new_trusted_sync_committee = TrustedSyncCommittee {
                     trusted_height: Height {
                         revision_number: trusted_height.revision_number,
                         revision_height: update.finalized_header.beacon.slot,
                     },
-                    sync_committee: if let Some(sync_committee) =
-                        update.next_sync_committee.as_ref()
-                    {
-                        ActiveSyncCommittee::Next(
-                            SyncCommittee::try_from(SyncCommitteeProto::from(
-                                sync_committee.clone(),
-                            ))
+                    sync_committee: ActiveSyncCommittee::Next(
+                        SyncCommittee::try_from(SyncCommitteeProto::from(next_sync_committee))
                             .map_err(|e| e.to_string())?,
-                        )
-                    } else {
-                        return Err("missing next sync committee".to_string());
-                    },
+                    ),
                 };
 
                 let account_update = AccountUpdate {

--- a/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
+++ b/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
@@ -1,3 +1,4 @@
+use beacon_api::errors::Error as BeaconError;
 use cgp::prelude::{CanRaiseError, HasErrorType};
 use eth_protos::union::ibc::lightclients::ethereum::v1::{
     LightClientUpdate as LightClientUpdateProto, SyncCommittee as SyncCommitteeProto,
@@ -44,7 +45,7 @@ where
         + CanRaiseError<String>
         + CanRaiseError<TryFromLightClientUpdateError>
         + CanRaiseError<TryFromSyncCommitteeError>
-        + CanRaiseError<beacon_api::errors::Error>
+        + CanRaiseError<BeaconError>
         + CanBuildAccountProof
         + HasBeaconApiClient
         + HasAlloyProvider,

--- a/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
+++ b/crates/ethereum-chain-components/src/impls/ethereum_to_cosmos/update_client_payload.rs
@@ -58,8 +58,14 @@ where
         target_height: &Chain::Height,
         _client_state: Chain::ClientState,
     ) -> Result<EthUpdateClientPayload<Preset>, Chain::Error> {
-        if target_height.revision_number != trusted_height.revision_number {
+        if !(target_height.revision_number == trusted_height.revision_number) {
             return Err(Chain::raise_error("revision number mismatch"));
+        }
+
+        if !(trusted_height.revision_height < target_height.revision_height) {
+            return Err(Chain::raise_error(
+                "target height is less than trusted height",
+            ));
         }
 
         // need to know the finality update at the target height. so, fetching the latest one.
@@ -192,7 +198,7 @@ where
                     .map(|x| x.data)
                     .collect::<Vec<_>>();
 
-                if updates.len() as u64 != (target_period - trust_period + 1) {
+                if !(updates.len() as u64 == (target_period - trust_period + 1)) {
                     return Err(Chain::raise_error("missing light client updates"));
                 }
 


### PR DESCRIPTION
the way union light client is implemented, it can't update to an arbitrary slot.
- the exact `target_height` has to be a finalized one.
- if we miss a `finality_update`, there is no way to get back. we have to wait for the next one.

So, the current implementation assumes the `target_height` to be minimum and tries to update to a `height` that is higher than the `target_height`.